### PR TITLE
Fix theme switching bug: optimize transitions and prevent render freeze

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1761,7 +1760,6 @@
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1802,7 +1800,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2015,7 +2012,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2341,7 +2337,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3832,7 +3827,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3895,7 +3889,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3905,7 +3898,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4283,7 +4275,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4416,7 +4407,6 @@
       "integrity": "sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4510,7 +4500,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,11 +70,6 @@ function App() {
   };
 
   useEffect(() => {
-    document.body.style.background = colorTheme;
-    document.body.style.transition = 'background 0.5s ease-in-out';
-  }, [colorTheme]);
-
-  useEffect(() => {
     const timer = setTimeout(() => {
       setShowWelcome(false);
     }, 2500);
@@ -94,7 +89,14 @@ function App() {
           </div>
         ) : (
           // WRAP EVERYTHING IN A FLEX CONTAINER
-          <div className="min-h-screen flex flex-col">
+          <div 
+            key={currentThemeId}
+            className="min-h-screen flex flex-col"
+            style={{
+              background: colorTheme,
+              transition: 'background 0.15s ease-in-out'
+            }}
+          >
             <Navbar
               title="WordWizard"
               theme={theme}

--- a/src/index.css
+++ b/src/index.css
@@ -30,8 +30,3 @@
     animation: fadeIn 0.2s ease-out;
   }
 }
-
-/* Smooth body background transitions */
-body {
-  transition: background 0.3s ease-in-out;
-}


### PR DESCRIPTION
issue #27 
When switching between light and dark mode themes, the page would freeze and not update visually until the user scrolled. The transition was also slow and buggy. The background gradient was being applied to document.body via a useEffect hook, but the actual visible content was wrapped in a div with min-h-screen class. This caused two issues:

The body background wasn't visible (covered by the content div)
React wasn't triggering proper browser repaints when the theme changed
There were conflicting transition timings (0.3s in CSS, 0.5s in JS)
Solution Implemented
App.jsx - Direct Background Application

Moved the background gradient from document.body to the main content div as an inline style
Added key={currentThemeId} to force React to re-render when theme changes
Added inline transition: transition: 'background 0.15s ease-in-out'
Removed the useEffect hook that was manipulating the body style
index.css - Removed Redundant CSS

Removed the body transition rule that was conflicting with the inline style
Result: Theme switching is now fast (0.15s), smooth, and updates immediately without requiring scrolling. The key prop ensures React properly re-renders the component tree, forcing the browser to repaint correctly.
